### PR TITLE
Make config path user-independent

### DIFF
--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -195,7 +195,7 @@ When multiple sources provide the same configuration option, the latest one in t
 
 All values are optional.
 
-🪟 `C:\Users\<UserName>\AppData\Roaming\SISR\config\SISR.toml`  
+🪟 `%APPDATA%\SISR\config\SISR.toml`  
 🐧 `$XDG_CONFIG_HOME/sisr/SISR.toml`
 
 ```toml

--- a/docs/guides/usage.md
+++ b/docs/guides/usage.md
@@ -76,7 +76,7 @@ or even allowing you to change the emulated controller type without restarting S
 If you want to change the default configuration of SISR, for example to emulate Playstation controller by default  
 you can do by creating a config file in:  
 
-- 🪟 Windows: `C:\Users\<UserName>\AppData\Roaming\SISR\config\SISR.toml`  
+- 🪟 Windows: `%APPDATA%\SISR\config\SISR.toml`  
 - 🐧 Linux: `$XDG_CONFIG_HOME/sisr/SISR.toml`
 
 ### Example: Emulate DualShock4 controllers by default


### PR DESCRIPTION
## Description
` C:\Users\<UserName>\AppData\Roaming\SISR\config\SISR.toml` -> `%APPDATA%\SISR\config\SISR.toml`

## Related Issue
None

## Motivation and Context
It annoyed me.

## How Has This Been Tested?
I pasted the updated path into Windows Explorer.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all boxes that apply -->
- [ ] Bug fix (non-breaking change addressing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Put an `x` in all the boxes that apply -->
- [ ] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
